### PR TITLE
Fix for static builds on unix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,7 @@ endif()
 if (GLFW_INSTALL)
     install(TARGETS glfw EXPORT glfwTargets 
             RUNTIME DESTINATION bin 
+            ARCHIVE DESTINATION lib${LIB_SUFFIX}
             LIBRARY DESTINATION lib${LIB_SUFFIX})
 endif()
 


### PR DESCRIPTION
Inviwo static build on unix is failing (https://github.com/inviwo/inviwo/issues/9) due to missing archive destination in the install command (https://cmake.org/cmake/help/v3.0/command/install.html).  

Probably need to to test this on windows and mac as well. the call to install here does not exactly match the https://github.com/inviwo/inviwo/blob/master/cmake/installutils.cmake#L64-L84, but maybe that does not matter 

